### PR TITLE
Fix broken warning message

### DIFF
--- a/picker-ui.js
+++ b/picker-ui.js
@@ -68,7 +68,7 @@
             e.preventDefault();
             var selected = self.getSelected();
             if (selected.length === 0) {
-                alert(this.messages.mustSelect);
+                alert(self.messages.mustSelect);
             }
             else {
                 self.pick(selected);


### PR DESCRIPTION
If you click `pick` with nothing selected, there should be an error message popup explaining that nothing will happen. This is currently broken because of an issue with the picker-ui.js logic

`this` is not defined, so it should be `self` at that scope.